### PR TITLE
WIP: MAINT: clean getting Fiji binary

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,15 +29,6 @@ opts = dict(name=NAME,
             install_requires=REQUIRES,
             package_data=PACKAGE_DATA)
 
-class FijiCommand(setuptools.command.build_py.build_py):
-    """Downloads and unzips current version of Fiji."""
-    
-    def run(self):
-        self.run_command('cd ~')
-        self.run_command('wget https://downloads.imagej.net/fiji/latest/fiji-linux64.zip')
-        self.run_command('unzip fiji-linux64.zip')
-        setuptools.command.build_py.build_py.run(self)
-
 
 if __name__ == '__main__':
     setup(**opts)


### PR DESCRIPTION
This PR implements a function that

* allows the user to specify where Fiji is located by setting an environment variable
* checks to see if Fiji has already been downloaded (at least on Mac OS X and Linux)
* downloading Fiji for Linux if not

This PR still needs more documentation (especially on `FIJI_BIN`), which is why it's a WIP.
